### PR TITLE
[Common] extend Input and Button styles with variant options

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  `inline-flex items-center justify-center gap-2 whitespace-nowrap 
+  rounded-md font-medium transition-colors 
+  focus-visible:outline-none 
+  focus-visible:ring-2 
+  focus-visible:ring-ring 
+  disabled:pointer-events-none 
+  disabled:opacity-50 
+  [&_svg]:pointer-events-none 
+  [&_svg]:size-4 
+  [&_svg]:shrink-0`,
   {
     variants: {
       variant: {
@@ -14,6 +23,7 @@ const buttonVariants = cva(
         transparent: "bg-transparent text-text-primary",
         danger: "bg-error text-white hover:bg-error/80",
         link: "text-primary underline-offset-4 hover:underline",
+        icon: "bg-transparent text-border hover:text-border/80",
       },
       size: {
         sm: "h-8 rounded-md px-3 text-xs",
@@ -58,3 +68,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = "Button"
 
 export { Button, buttonVariants }
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,23 +1,50 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { cva } from "class-variance-authority"
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, maxLength, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className
-        )}
-        ref={ref}
-        maxLength={maxLength}
-        {...props}
-      />
-    )
-  }
-)
+const SearchVariants = cva(
+  `flex w-full border placeholder:text-muted-foreground text-base`,
+  {
+    variants:{
+      variant:{
+        default: `h-9 rounded-md border-input 
+        bg-transparent px-3 py-1
+        file:border-0 file:bg-transparent 
+        file:text-sm file:font-medium 
+        file:text-foreground 
+        focus-visible:outline-none 
+        focus-visible:ring-1 
+        focus-visible:ring-ring 
+        disabled:cursor-not-allowed 
+        disabled:opacity-50 
+        md:text-sm`,
+
+        search: `h-11 rounded-full border-border bg-white pl-10 pr-10 `
+      },
+    },
+    defaultVariants:{
+      variant:"default"
+    },
+  },
+);
+
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.ComponentProps<"input"> & { variant?: "default" | "search" }
+>(({ className, type, maxLength, variant = "default", ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        SearchVariants({variant}), className
+      )}
+      ref={ref}
+      maxLength={maxLength}
+      {...props}
+    />
+  )
+})
 Input.displayName = "Input"
 
 export { Input }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils"
 import { cva } from "class-variance-authority"
 
 const SearchVariants = cva(
-  `flex w-full border placeholder:text-muted-foreground text-base`,
+  `flex w-full border placeholder:text-text-secondary text-base`,
   {
     variants:{
       variant:{
@@ -48,3 +48,4 @@ const Input = React.forwardRef<
 Input.displayName = "Input"
 
 export { Input }
+


### PR DESCRIPTION
## What? 작업 내용
- 버튼 컴포넌트에 "icon" variant 추가
- input 컴포넌트에 "search", "default" variant 확장

## How? 작업 방식
- 

## Test? 테스트 방법
- 

## More? 기타 참고사항
- #1 
- #6