### PR TITLE
(Fix) foce logout on refresh token expired

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,10 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from '@/router';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/store/auth';
-import { useGlobalErrorToast } from '@/hooks/useGlobalErrorToast';
-// import { useViewportHeight } from './hooks/useViewportHeight';
-// import { AnimatePresence } from 'motion/react';
+// import { useGlobalErrorToast } from '@/hooks/useGlobalErrorToast';
 
 function App() {
-  useGlobalErrorToast();
-  // useViewportHeight();
+  // useGlobalErrorToast();
   //토큰 복원
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
@@ -18,9 +15,7 @@ function App() {
   }, []);
 
   return (
-    // <AnimatePresence mode="wait">
       <RouterProvider router={router} />
-    // </AnimatePresence>
   );
 }
 

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -3,8 +3,10 @@ import { Header } from '@/components/layout/header';
 import { Navbar } from '@/components/layout/navbar';
 import { useAuthStore } from '@/store/auth';
 import { Toaster } from '@/components/ui/toaster';
+import { useGlobalErrorToast } from '@/hooks/useGlobalErrorToast';
 
 export default function MainLayout() {
+  useGlobalErrorToast();
   const location = useLocation();
 
   const token = useAuthStore((state) => state.token);

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -105,6 +105,19 @@ instance.interceptors.response.use(
         }
       }
     }
+    else if(res?.status === 409){
+      const message = res?.data?.message;
+      if(message?.includes("리프레시 토큰")){
+        setTimeout(()=>{
+          publishErrorToast("로그아웃되었습니다. 다시 로그인 해주세요.");
+        },3000)
+          // toast({title: "로그아웃되었습니다. 다시 로그인 해주세요."});
+        console.log('🔑 로그아웃됨');
+        useAuthStore.getState().clearToken();
+        window.location.href = "/login";
+        return Promise.reject(error);
+      }
+    }
 
     return Promise.reject(error);
   }


### PR DESCRIPTION
## What? 작업 내용
- 리프레시 토큰 만료 시 강제 로그아웃 추가
- globalErrorToast 사용 가능하게 디버깅

## How? 작업 방식
- 409 + 리프레시 토큰 포함 메세지 반환 시 강제 로그아웃.

## Test? 테스트 방법
- 

## More? 기타 참고사항
- 
