### PR TITLE
(Fix) show proper data for monthly my rank continous section

### DIFF
--- a/src/features/Competition/components/myRankCard.tsx
+++ b/src/features/Competition/components/myRankCard.tsx
@@ -50,7 +50,7 @@ export default function MyRankCard({ rankingView, competitionTime }: MyRankCardP
       ? myRanking?.daily?.elapsedTime
       : rankingView === 'weekly'
         ? `${myRanking?.weekly?.elapsedTime}일 연속 참여`
-        : `${myRanking?.weekly?.elapsedTime}일 연속 참여`;
+        : `${myRanking?.monthly?.elapsedTime}일 연속 참여`;
 
   return (
     <>


### PR DESCRIPTION
## What? 작업 내용
- 월간 내 랭킹 바에서 연속 참여 일 수가 undefined로 나오는 에러 해결

## How? 작업 방식
- 

## Test? 테스트 방법
- 

## More? 기타 참고사항
- 
