### PR TITLE
(Fix) no more reissue repeats my live ranking

### DIFF
--- a/src/features/Competition/hooks/useMyRanking.ts
+++ b/src/features/Competition/hooks/useMyRanking.ts
@@ -81,7 +81,7 @@ export const useDailyMyPolling = (enabled: boolean) => {
     const interval = setInterval(fetchInitial, 3000); // polling 3초
 
     return () => clearInterval(interval);
-  }, [enabled, queryClient]);
+  }, [enabled, queryClient, token]);
 
   return liveRanking;
 };


### PR DESCRIPTION
## What? 작업 내용
- 내 랭킹을 실시간으로 호출해올 때, 토큰 재발급이 한 번 일어난 후 매 요청마다 재발급이 되었던 이슈 해결

## How? 작업 방식
- polling 하는 useEffect의 의존성에 token 추가

## Test? 테스트 방법
- 

## More? 기타 참고사항
- 
