### PR TITLE
(Hotfix) show fallback on daily ranking data not ready

### DIFF
--- a/src/features/Competition/Ranking.tsx
+++ b/src/features/Competition/Ranking.tsx
@@ -110,7 +110,7 @@ export default function Ranking() {
                 <LiveBarChart />
               ) : isAggregationTime ? (
                 <AggregationNotice />
-              ) : topRankings?.daily ? (
+              ) : topRankings?.daily && topRankings?.daily.length > 0 ? (
                 <StaticBarChart rankingData={topRankings?.daily} type="daily" />
               ) : (
                 <div className="flex items-center h-[436px]">아직 랭킹 데이터가 없어요.</div>


### PR DESCRIPTION
## What? 작업 내용
- 일일 대회 데이터 없을 시 fallback 보여줌

## How? 작업 방식
- 

## Test? 테스트 방법
- 

## More? 기타 참고사항
- 
